### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 - [Omniglot](https://github.com/brendenlake/omniglot), dataset has been used for training the model 
   - The dataset has 1623 character classes, each with 20 examples.
-  - The model tries to build a few shot classifier using the ides presented in the paper by **Gregory et. al** for the dataset.
+  - The model tries to build a few shot classifier using the ideas presented in the paper by **Gregory et. al** for the dataset.
   
 ### Reading
   - [Siamese Neural Networks for One-Shot Image Recognition](https://www.cs.cmu.edu/~rsalakhu/papers/oneshot1.pdf)


### PR DESCRIPTION
Fixed a typo in line 12: it should be 'ideas presented' and not 'ides presented'.
Thanks.